### PR TITLE
CI: Only run Codecov on Ubuntu jobs and update to v2

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
       run: pip install .[dev]
     - name: Test with pytest
       run: pytest --cov=mesa tests/ --cov-report=xml
-    - if: matrix.os == "ubuntu"
+    - if: matrix.os == 'ubuntu'
       name: Codecov
       uses: codecov/codecov-action@v2
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,8 +42,9 @@ jobs:
       run: pip install .[dev]
     - name: Test with pytest
       run: pytest --cov=mesa tests/ --cov-report=xml
-    - name: Codecov
-      uses: codecov/codecov-action@v1.0.15
+    - if: matrix.os == "ubuntu"
+      name: Codecov
+      uses: codecov/codecov-action@v2
 
   lint-flake:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It isn't necessary to run Codecov on all jobs, so only run them on the Ubuntu jobs.

Also updates the codecov/codecov-action to v2.