### PR TITLE
CI: Add GitHub Action to append installation instructions to PRs

### DIFF
--- a/.github/workflows/pr_branch_message.yml
+++ b/.github/workflows/pr_branch_message.yml
@@ -1,0 +1,30 @@
+name: PR install note
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-install-note:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Add PR install note
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          PR_BODY=$(gh pr view $PR_NUMBER --json body -q .body)
+          FORK_NAME=$(gh pr view $PR_NUMBER --json headRepositoryOwner -q .headRepositoryOwner.login)
+          PR_BRANCH=$(gh pr view $PR_NUMBER --json headRefName -q .headRefName)
+          REPO_OWNER=${FORK_NAME:-projectmesa}
+          INSTALL_NOTE="
+
+You can install this PR branch with:
+\`\`\`
+pip install -U -e git+https://github.com/${REPO_OWNER}/mesa@${PR_BRANCH}#egg=mesa
+\`\`\`"
+
+          NEW_PR_BODY="${PR_BODY}${INSTALL_NOTE}"
+          gh pr edit $PR_NUMBER --body "$NEW_PR_BODY"


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that automatically appends installation instructions to newly opened pull requests. The workflow does the following:

- Triggers on the 'pull_request' event, specifically when a PR is opened
- Uses the GitHub CLI to fetch PR details (body, fork name, branch name)
- Determines the correct repository owner (projectmesa or fork owner)
- Constructs an installation note with the appropriate pip install command
- Appends the installation note to the end of the PR description
- Updates the PR with the new description

This addition will make it easier for reviewers and other contributors to test PRs by providing clear instructions on how to install the PR branch. It works for both PRs from the main repository and from forks.

The installation note format is:

You can install this PR branch with:
```
pip install -U -e git+https://github.com/${REPO_OWNER}/mesa@${PR_BRANCH}#egg=mesa
```

Where ${REPO_OWNER} is either 'projectmesa' or the fork owner's name, and ${PR_BRANCH} is the name of the branch associated with the PR.